### PR TITLE
Update to 1.3.0

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -3,7 +3,8 @@
 # and underscores. A good package name should reflect your organization's
 # name or the intended use of these models
 name: 'bigquery_demo_project'
-version: '1.0.0'
+version: '1.3.0'
+require-dbt-version: '>=1.3.0'
 config-version: 2
 
 # This setting configures which "profile" dbt uses for this project.
@@ -22,7 +23,7 @@ snapshot-paths: ["snapshots"]
 target-path: "target"  # directory which will store compiled SQL files
 clean-targets:         # directories to be removed by `dbt clean`
     - "target"
-    - "dbt_modules"
+    - "dbt_packages"
 
 
 # Configuring models

--- a/packages.yml
+++ b/packages.yml
@@ -1,5 +1,5 @@
 packages:
   - package: dbt-labs/dbt_utils
-    version: 0.8.0
+    version: 0.9.2
   - package: dbt-labs/dbt_external_tables
-    version: 0.8.0
+    version: 0.8.2


### PR DESCRIPTION
We want to work on top of our latest releases. Therefore, this PR addresses the update to dbt version to 1.3.0.

More info here:
https://github.com/dbt-labs/dbt-core/releases